### PR TITLE
Redesign landing page

### DIFF
--- a/my-shadcn-app/README.md
+++ b/my-shadcn-app/README.md
@@ -20,6 +20,12 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+### UI Highlights
+
+- Redesigned hero section with a subtle gradient background
+- Feature cards provide a quick overview of key functions
+- Navigation bar includes a dark mode toggle
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/my-shadcn-app/src/app/page.tsx
+++ b/my-shadcn-app/src/app/page.tsx
@@ -2,9 +2,9 @@
 "use client";
 
 import { Navbar } from "@/components/navbar";
-import { ToggleBlock } from "@/components/toggle-block";
 import { FlowTimeline } from "@/components/flow-timeline";
 import { Button } from "@/components/ui/button";
+import { motion } from "framer-motion";
 
 export default function HomePage() {
   return (
@@ -14,44 +14,55 @@ export default function HomePage() {
       {/* Hero */}
       <section
         id="hero"
-        className="relative h-screen flex flex-col items-center justify-center text-center px-6"
+        className="relative flex flex-col items-center justify-center h-screen text-center bg-gradient-to-br from-pastelBlue via-pastelPink to-pastelGreen"
       >
-        {/* 배경 패턴 */}
-        <div className="absolute inset-0 bg-pastelPink mix-blend-multiply opacity-20 rounded-3xl animate-pulse"></div>
-
-        <div className="relative z-10 max-w-xl bg-white p-8 rounded-xl shadow-lg">
-          <h2 className="text-3xl font-bold mb-4 text-pastelBlue">
-            전세 거래, 완전 새로워진 경험
+        <div className="absolute inset-0 bg-white/50 dark:bg-gray-800/50 mix-blend-multiply"></div>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className="relative z-10 max-w-2xl p-8 rounded-xl backdrop-blur-md bg-white/80 dark:bg-gray-900/80 shadow-xl"
+        >
+          <h2 className="text-4xl font-extrabold mb-4 text-pastelBlue">
+            새로운 전세 경험을 만나보세요
           </h2>
-          <p className="text-gray-600 mb-6">
-            복잡한 전세 과정을 블록으로 쪼개어<br />
-            손쉽게 관리하고 놓치지 마세요.
+          <p className="text-gray-700 dark:text-gray-300 mb-6">
+            복잡한 과정을 깔끔하게 관리하고 실시간 알림을 받아보세요.
           </p>
-          <div className="flex justify-center space-x-4">
+          <div className="flex justify-center gap-4">
             <Button>무료 체험</Button>
             <Button variant="outline">문의하기</Button>
           </div>
-        </div>
+        </motion.div>
       </section>
 
       {/* Features */}
       <section id="features" className="container mx-auto px-6 py-16">
-        <h3 className="text-2xl font-bold mb-6 text-center text-pastelBlue">
+        <h3 className="text-3xl font-bold mb-8 text-center text-pastelBlue">
           주요 기능
         </h3>
-        <ToggleBlock title="단계별 가이드">
-          <ul className="list-disc list-inside space-y-1">
-            <li>매물 요청 폼</li>
-            <li>중개인 자동 매칭</li>
-            <li>체크리스트 관리</li>
-          </ul>
-        </ToggleBlock>
-        <ToggleBlock title="실시간 알림">
-          <p>이메일·푸시 알림으로 중요한 일정을 알려드립니다.</p>
-        </ToggleBlock>
-        <ToggleBlock title="계약서 관리">
-          <p>자동 문서 생성부터 공유·보관까지 한번에!</p>
-        </ToggleBlock>
+        <div className="grid md:grid-cols-3 gap-6">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-6">
+            <h4 className="font-semibold mb-2">단계별 가이드</h4>
+            <ul className="list-disc list-inside space-y-1 text-gray-700 dark:text-gray-300">
+              <li>매물 요청 폼</li>
+              <li>중개인 자동 매칭</li>
+              <li>체크리스트 관리</li>
+            </ul>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-6">
+            <h4 className="font-semibold mb-2">실시간 알림</h4>
+            <p className="text-gray-700 dark:text-gray-300">
+              이메일과 푸시로 중요한 일정을 알려드립니다.
+            </p>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-6">
+            <h4 className="font-semibold mb-2">계약서 관리</h4>
+            <p className="text-gray-700 dark:text-gray-300">
+              자동 문서 생성부터 공유까지 한번에 처리하세요.
+            </p>
+          </div>
+        </div>
       </section>
 
       {/* Flow */}
@@ -63,8 +74,8 @@ export default function HomePage() {
       </section>
 
       {/* Contact */}
-      <section id="contact" className="bg-white py-16 px-6">
-        <div className="max-w-md mx-auto bg-pastelGreen bg-opacity-50 p-8 rounded-xl shadow-lg">
+      <section id="contact" className="py-16 px-6 bg-pastelGreen/20">
+        <div className="max-w-md mx-auto bg-white dark:bg-gray-800 p-8 rounded-xl shadow-lg">
           <h3 className="text-xl font-bold mb-4 text-pastelBlue">문의하기</h3>
           <form className="space-y-4">
             <input

--- a/my-shadcn-app/src/components/navbar.tsx
+++ b/my-shadcn-app/src/components/navbar.tsx
@@ -2,13 +2,14 @@
 "use client";
 
 import Link from "next/link";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export function Navbar() {
   return (
-    <nav className="bg-white/70 backdrop-blur-md shadow-sm">
+    <nav className="bg-gradient-to-r from-pastelPink/40 via-pastelBlue/40 to-pastelGreen/40 backdrop-blur-md shadow-sm">
       <div className="container mx-auto flex items-center justify-between px-6 py-4">
         <h1 className="text-2xl font-bold text-pastelBlue">JeonseFlow</h1>
-        <div className="flex space-x-4 text-pastelBlue">
+        <div className="flex items-center space-x-4 text-pastelBlue">
           {["홈", "기능", "플로우", "문의"].map((t) => (
             <Link
               key={t}
@@ -18,6 +19,7 @@ export function Navbar() {
               {t}
             </Link>
           ))}
+          <ThemeToggle />
         </div>
       </div>
     </nav>

--- a/my-shadcn-app/src/components/theme-provider.tsx
+++ b/my-shadcn-app/src/components/theme-provider.tsx
@@ -9,3 +9,4 @@ export function ThemeProvider({
 }: React.ComponentProps<typeof NextThemesProvider>) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }
+

--- a/my-shadcn-app/src/components/theme-toggle.tsx
+++ b/my-shadcn-app/src/components/theme-toggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- redesign hero with gradient background and motion animation
- show feature cards instead of toggle blocks
- update contact section style
- add dark mode theme toggle to the navigation bar
- document UI highlights in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0ca226e88320916c2499b60e4c77